### PR TITLE
Define VIP mission units for SOG USA and VIETCONG

### DIFF
--- a/LRX_Template/mod_template/SOG_USA/classnames_east.sqf
+++ b/LRX_Template/mod_template/SOG_USA/classnames_east.sqf
@@ -70,6 +70,18 @@ militia_vehicles = [
 	"vn_b_wheeled_m151_02_mp"
 ];
 
+guard_squad = [
+	"vn_b_men_aus_army_70_22",
+	"vn_b_men_aus_army_70_08",
+	"vn_b_men_aus_army_70_08",
+	"vn_b_men_aus_army_70_08",
+	"vn_b_men_aus_army_70_08"
+];
+
+guard_loadout_overide = [];
+
+vip_vehicle = "vn_b_wheeled_lr2a_02_aus_army";
+
 opfor_boats = [
 	"vn_o_boat_02_mg_02",
 	"vn_o_boat_01_mg_02",

--- a/LRX_Template/mod_template/SOG_VIETCONG/classnames_east.sqf
+++ b/LRX_Template/mod_template/SOG_VIETCONG/classnames_east.sqf
@@ -62,6 +62,18 @@ militia_vehicles = [
 	"vn_o_wheeled_btr40_mg_02_nva65"
 ];
 
+guard_squad = [
+	"vn_o_men_vc_01",
+	"vn_o_men_vc_12",
+	"vn_o_men_vc_12",
+	"vn_o_men_vc_12",
+	"vn_o_men_vc_12"
+];
+
+guard_loadout_overide = [];
+
+vip_vehicle = "vn_c_car_02_01";
+
 opfor_boats = [
 	"vn_o_boat_02_mg_02",
 	"vn_o_boat_01_mg_02",


### PR DESCRIPTION
This defines the units for the VIP mission for the SOG USA and VIETCONG factions. When they are not defined, the default behavior in the mission takes over and spawns Gendarmerie units and a modern offroad truck, which are out of place when using these factions.